### PR TITLE
Add Exporter and Test::Requires to %is_special

### DIFF
--- a/lib/Perl/Critic/Policy/TooMuchCode/ProhibitUnusedImport.pm
+++ b/lib/Perl/Critic/Policy/TooMuchCode/ProhibitUnusedImport.pm
@@ -15,7 +15,7 @@ sub applies_to           { return 'PPI::Document' }
 #---------------------------------------------------------------------------
 
 # special modules, where the args of import do not mean the symbols to be imported.
-my %is_special = map { $_ => 1 } qw(Getopt::Long MooseX::Foreign MouseX::Foreign);
+my %is_special = map { $_ => 1 } qw(Getopt::Long MooseX::Foreign MouseX::Foreign Exporter Test::Requires);
 
 sub violates {
     my ( $self, $elem, $doc ) = @_;

--- a/t/TooMuchCode/ProhibitUnusedImport.run
+++ b/t/TooMuchCode/ProhibitUnusedImport.run
@@ -70,3 +70,17 @@ print 42;
 
 use Foo ('BAR', 'QUX');
 print 42;
+
+## name Exporter
+## failures 0
+## cut
+
+use Exporter qw/import/;
+print 42;
+
+## name Test::Requires
+## failures 0
+## cut
+
+use Test::Requires qw/DBI/;
+print 42;


### PR DESCRIPTION
It would be nice if these two are special-cased (UnusedImport only fails to recognize Test::Requires when it imports a top-level module like DBI and CGI).
