### PR TITLE
Make UnusedImport handle general cases

### DIFF
--- a/t/TooMuchCode/ProhibitUnusedImport.run
+++ b/t/TooMuchCode/ProhibitUnusedImport.run
@@ -64,7 +64,14 @@ print 42;
 use Importer 'Foo' => ( 'BAR', 'QUX' );
 print 42;
 
-## todo General syntax. List of str
+## name General syntax. str
+## failures 1
+## cut
+
+use Foo 'BAR';
+print 42;
+
+## name General syntax. List of str
 ## failures 2
 ## cut
 


### PR DESCRIPTION
This PR allows UnusedImport to recognize general cases (a literal/string, and a list of string).

Maybe Importer and its friends should be special-cased so that we don't need to ```find``` twice, or not?
