### PR TITLE
Recognize subroutine references as used imports

### DIFF
--- a/lib/Perl/Critic/Policy/TooMuchCode/ProhibitUnusedImport.pm
+++ b/lib/Perl/Critic/Policy/TooMuchCode/ProhibitUnusedImport.pm
@@ -24,7 +24,21 @@ sub violates {
     $self->gather_imports_generic( \%imported, $elem, $doc );
 
     my %used;
-    for my $el_word (@{ $elem->find( sub { $_[1]->isa('PPI::Token::Word') }) ||[]}) {
+    for my $el_word (
+        @{
+            $elem->find(
+                sub {
+                    $_[1]->isa('PPI::Token::Word')
+                        || ( $_[1]->isa('PPI::Token::Symbol')
+                        && $_[1]->symbol_type eq '&' );
+                }
+                )
+                || []
+        }
+    ) {
+        if ( $el_word->isa('PPI::Token::Symbol') ) {
+            $el_word =~ s{^&}{};
+        }
         $used{"$el_word"}++;
     }
 

--- a/t/TooMuchCode/ProhibitUnusedImport.run
+++ b/t/TooMuchCode/ProhibitUnusedImport.run
@@ -84,3 +84,10 @@ print 42;
 
 use Test::Requires qw/DBI/;
 print 42;
+
+## name subroutine ref
+## failures 0
+## cut
+
+use Encode qw( decode );
+my $ref = \&decode;


### PR DESCRIPTION
Closes #11 

Thanks for your work on this module! I was hoping to begin including it with our $work Perl::Critic policies. This takes care of one of the issues which is blocking us right now.