### PR TITLE
Match strict equivalent modules from Perl::Critic

### DIFF
--- a/lib/Perl/Critic/Policy/TooMuchCode/ProhibitExtraStricture.pm
+++ b/lib/Perl/Critic/Policy/TooMuchCode/ProhibitExtraStricture.pm
@@ -2,6 +2,7 @@ package Perl::Critic::Policy::TooMuchCode::ProhibitExtraStricture;
 use strict;
 use warnings;
 use Perl::Critic::Utils ':booleans';
+use Perl::Critic::Utils::Constants qw(@STRICT_EQUIVALENT_MODULES);
 use parent 'Perl::Critic::Policy';
 
 sub default_themes       { return qw( maintenance )     }
@@ -14,13 +15,7 @@ sub supported_parameters {
             description => 'Modules which enables strictures.',
             behavior    => 'string list',
             list_always_present_values => [
-                'Moose',
-                'Mouse',
-                'Moo',
-                'Mo',
-                'Moose::Role',
-                'Mouse::Role',
-                'Moo::Role',
+                @STRICT_EQUIVALENT_MODULES,
                 'Test2::V0',
             ],
         }

--- a/t/TooMuchCode/ProhibitExtraStricture.run
+++ b/t/TooMuchCode/ProhibitExtraStricture.run
@@ -37,3 +37,10 @@ use strict;
 use Moose;
 use strict;
 print 42;
+
+## name strict and Test2::V0
+## failures 1
+## cut
+use strict;
+use Test2::V0;
+print 42;


### PR DESCRIPTION
This is an attempt to fix #20 by reusing the list of strict equivalent modules from `Perl::Critic::Utils::Constants`.

Since `Test2::V0` is not included there (yet?), I've also added an explicit test case for it to make sure it remain compatible with the previous list of modules on this side.

I hope this idea is useful; please review and merge, or let me know how to improve it further.