### PR TITLE
Added missing colon in the documentation

### DIFF
--- a/lib/Perl/Critic/Policy/TooMuchCode/ProhibitDuplicateLiteral.pm
+++ b/lib/Perl/Critic/Policy/TooMuchCode/ProhibitDuplicateLiteral.pm
@@ -68,7 +68,7 @@ The default whitelist is 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, -1, -2, -3, -4, -5, -6, -
 
 To opt-out more, add C<whitelist_numbers> like this in C<.perlcriticrc>
 
-    [TooMuchCode:ProhibitDuplicateLiteral]
+    [TooMuchCode::ProhibitDuplicateLiteral]
     whitelist_numbers = 42, 10
 
 This configurable parameter appends to the default whitelist and there


### PR DESCRIPTION
Added missing colon, unfortunately it was not in Perl::Critic::Policy::TooMuchCode::ProhibitExcessiveColons

Awesome policies BTW