### PR TITLE
Allow configurable strings to be duplicates

### DIFF
--- a/t/TooMuchCode/ProhibitDuplicateLiteral.run
+++ b/t/TooMuchCode/ProhibitDuplicateLiteral.run
@@ -14,6 +14,24 @@ print "Forty three";
 print "Forty two";
 print "Forty two";
 
+## name allowed duplicate string
+## parms { allowed_strings => '"Forty two"' }
+## failures 0
+## cut
+
+print "Forty two";
+print "Forty two";
+
+## name multiple allowed duplicate strings
+## parms { allowed_strings => '"Forty two" \'Forty three\'' }
+## failures 0
+## cut
+
+print "Forty two";
+print "Forty two";
+print "Forty three";
+print "Forty three";
+
 ## name Strings with different different quote.
 ## failures 1
 ## cut


### PR DESCRIPTION
This PR is an attempt to fix #25 by allowing quoted strings specified via `allowed_strings` configuration option to be present more than once.

My first idea was to use space or `,` as the separator between allowed strings, but that might be problematic when someone would like to allow a string containing more than one words.

Since we have a Perl::Critic policy at hand, which uses PPI anyway, I decided to reuse that module to detect any quoted tokens coming in via the configuration option. Hope this approach provides good enough balance between all the factors.

Please review and merge, or let me know how to improve it further.