### PR TITLE
Count symbol Re-exporting as uses

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+	- ProhibitUnusedImport: Deal with the special form of assigning to @EXPORT and @EXPORT_OK. Github PR #29, issue #18
+
 0.17
 	- Released at 2021-09-20T20:44:45+0900
 	- ProhibitDuplicateLiteral: add "whitelist" parameter

--- a/lib/Perl/Critic/Policy/TooMuchCode/ProhibitUnusedImport.pm
+++ b/lib/Perl/Critic/Policy/TooMuchCode/ProhibitUnusedImport.pm
@@ -151,6 +151,25 @@ sub __get_symbol_usage {
         }
     }
 
+    # Gather usages in the exact form of:
+    #     our @EXPORT = qw( ... );
+    #     our @EXPORT_OK = qw( ... );
+    for my $st (@{ $doc->find('PPI::Statement::Variable') || [] }) {
+        next unless $st->schildren == 5;
+
+        my @children = $st->schildren;
+        next unless $children[0]->content() eq 'our'
+            && ($children[1]->content() eq '@EXPORT'
+                || $children[1]->content() eq '@EXPORT_OK')
+            && $children[2]->content() eq '='
+            && $children[3]->isa('PPI::Token::QuoteLike::Words')
+            && $children[4]->content() eq ';';
+
+        for my $w ($children[3]->literal) {
+            $usage->{ $w }++;
+        }
+    }
+
     return;
 }
 

--- a/t/TooMuchCode/ProhibitUnusedImport.run
+++ b/t/TooMuchCode/ProhibitUnusedImport.run
@@ -114,3 +114,17 @@ use lib $Bin . "/../../../../";
 use FindBin qw( $Bin );
 my $bar;
 print "Here it is: $Bin";
+
+## name re-exporting is a form of using. with @EXPORT_OK. github issue 18.
+## failures 0
+## cut
+
+use Foo qw( foo $bar @baz );
+our @EXPORT_OK = qw(foo $bar @baz);
+
+## name re-exporting is a form of using. with @EXPORT. github issue 18.
+## failures 0
+## cut
+
+use Foo qw( foo $bar @baz );
+our @EXPORT = qw(foo $bar @baz);

--- a/t/TooMuchCode/ProhibitUnusedImport.run
+++ b/t/TooMuchCode/ProhibitUnusedImport.run
@@ -128,3 +128,16 @@ our @EXPORT_OK = qw(foo $bar @baz);
 
 use Foo qw( foo $bar @baz );
 our @EXPORT = qw(foo $bar @baz);
+
+## name re-exporting. with code sample from github issue 18.
+## failures 0
+## cut
+
+use Mojo::JSON qw(decode_json encode_json);
+
+  {
+      our @EXPORT_OK = qw(
+          decode_json
+          encode_json
+      );
+  }

--- a/t/TooMuchCode/ProhibitUnusedImport.run
+++ b/t/TooMuchCode/ProhibitUnusedImport.run
@@ -141,3 +141,10 @@ use Mojo::JSON qw(decode_json encode_json);
           encode_json
       );
   }
+
+## name other var assigments with symbols in their literal forms should not be counted as usage
+## failures 3
+## cut
+
+use Foo qw(foo $bar @baz);
+my @foo = qw(foo $bar @baz);


### PR DESCRIPTION
This deal the case described in issue #18 .

`@EXPORT` and `@EXPORT_OK` are so special, that,  assigning quoted symbols to them should be consider to be the usages of those symboles.

```perl
# Importing 3 symbols. subroutine foo, scalar variable $bar, and array varible @baz
use Foo qw(foo $bar @baz); 

# Not using those 3 symbols, because the elements in @stuff are just 3 strings 
my @stuff = qw(foo $bar @baz);

# Using those 3 symbols, because these are symbols that will
# be re-exported whith current module is imported.
our @EXPORT = qw(foo $bar @baz);
```

In this PR, we detect the existense of  assigning a `qw()` to `@EXPORT` or `@EXPORT_OK`, and count the words in `qw()` as usages of those symbols.

