### PR TITLE
Improve descriptions of duplicates

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+	- ProhibitDuplicateLiteral: Improve description by including the literal and excluding line and column numbers.
+
 0.18
 	- Released at 2021-09-29T08:43:04+0900
 	- ProhibitDuplicateLiteral: the parameter "whitelist" is renamed to "allowlist"

--- a/lib/Perl/Critic/Policy/TooMuchCode/ProhibitDuplicateLiteral.pm
+++ b/lib/Perl/Critic/Policy/TooMuchCode/ProhibitDuplicateLiteral.pm
@@ -50,7 +50,7 @@ sub violates {
 
         if ($firstSeen{"$val"}) {
             push @violations, $self->violation(
-                "A duplicate literal value at line: " . $el->line_number . ", column: " . $el->column_number,
+                "A duplicate literal: '$el->string'",
                 "Another literal value in the same piece of code.",
                 $el,
             );
@@ -64,7 +64,7 @@ sub violates {
         next if $self->{"_allowlist"}{$val};
         if ($firstSeen{$val}) {
             push @violations, $self->violation(
-                "A duplicate literal value at line: " . $el->line_number . ", column: " . $el->column_number,
+                "A duplicate literal: $el->content",
                 "Another literal value in the same piece of code.",
                 $el,
             );


### PR DESCRIPTION
This PR is a proposal to improve the description of detected cases of duplicate literals and subroutines.

The current description of those violations include the line and column numbers, which I often found too verbose with default settings of perlcritic. Whenever that information is required, it can be obtained by choosing an appropriate [`--verbose` format](https://metacpan.org/dist/Perl-Critic/view/bin/perlcritic#-verbose-N-|-FORMAT) for `perlcritic` that includes `%l` and/or `%c` in its format specification.

According to the documentation of [description of Perl::Critic::Violation](https://metacpan.org/pod/Perl::Critic::Violation#description())

> this value may change on a per violation basis

so I propose to let the message include the actual literal that is detected as a duplicate.

Please review and merge, or let me know how to improve it further.

ps.: I wasn't sure how you would prefer to include this in `Changes`, so I left that out for now.