### PR TITLE
Allow duplicates for specially named code blocks

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+	- ProhibitDuplicateSub: Allow multiple BEGIN, UNITCHECK, CHECK, INIT and END code blocks
+
 0.18
 	- Released at 2021-09-29T08:43:04+0900
 	- ProhibitDuplicateLiteral: the parameter "whitelist" is renamed to "allowlist"

--- a/lib/Perl/Critic/Policy/TooMuchCode/ProhibitDuplicateSub.pm
+++ b/lib/Perl/Critic/Policy/TooMuchCode/ProhibitDuplicateSub.pm
@@ -7,6 +7,20 @@ use parent 'Perl::Critic::Policy';
 sub default_themes       { return qw( bugs maintenance )     }
 sub applies_to           { return 'PPI::Document' }
 
+sub initialize_if_enabled {
+    my ($self, $config) = @_;
+
+    $self->{_allow_duplicates_for} = {
+        BEGIN     => 1,
+        UNITCHECK => 1,
+        CHECK     => 1,
+        INIT      => 1,
+        END       => 1,
+    };
+
+    return $TRUE;
+}
+
 sub violates {
     my ($self, undef, $doc) = @_;
     my $packages = $doc->find('PPI::Statement::Package') || [];
@@ -20,6 +34,7 @@ sub violates {
     my @duplicates;
     for my $sub (@$subdefs) {
         next if $sub->forward || (! $sub->name);
+        next if $self->{_allow_duplicates_for}{$sub->name};
 
         if (exists $seen{ $sub->name }) {
             push @duplicates, $seen{ $sub->name };

--- a/t/TooMuchCode/ProhibitDuplicateSub.run
+++ b/t/TooMuchCode/ProhibitDuplicateSub.run
@@ -57,3 +57,18 @@ package Here {
 package There {
     sub inc { 1 + $_[0] }
 };
+
+## name Multiple BEGIN, UNITCHECK, CHECK, INIT or END blocks
+## failures 0
+## cut
+
+BEGIN {}
+BEGIN {}
+UNITCHECK {}
+UNITCHECK {}
+CHECK {}
+CHECK {}
+INIT {}
+INIT {}
+END {}
+END {}


### PR DESCRIPTION
This PR is a proposal to allow duplicate definitions of the specially named built-in BEGIN, UNITCHECK, CHECK, INIT, and END codeblocks.

In one of my code bases I got a ProhibitDuplicateSub violation about having two `BEGIN` blocks, so I checked the [BEGIN, UNITCHECK, CHECK, INIT and END](https://perldoc.perl.org/perlmod#BEGIN,-UNITCHECK,-CHECK,-INIT-and-END) section of perlmod. It states that:

> Five specially named code blocks are [...] BEGIN, UNITCHECK, CHECK, INIT, and END blocks.

> These code blocks can be prefixed with sub to give the appearance of a subroutine [...]

> One should note that these code blocks don't really exist as named subroutines (despite their appearance)

> [...] you can have more than one of these code blocks in a program, and they will get all executed at the appropriate moment.

Based on the above I decided to write a test for these cases and also fix ProhibitDuplicateSub in a follow-up commit.

Please review and merge, or let me know how to improve it further!