### PR TITLE
fix spelling

### DIFF
--- a/lib/Perl/Critic/Policy/TooMuchCode/ProhibitLargeBlock.pm
+++ b/lib/Perl/Critic/Policy/TooMuchCode/ProhibitLargeBlock.pm
@@ -46,7 +46,7 @@ This policy scan for large code blocks of the following type.
     do { ... };
 
 By default a large block is one with more than 10 statements. If
-you need an other limit, you can set the parameter
+you need another limit, you can set the parameter
 C<block_statement_count_limit>.
 
 For example in the I<.perlcriticrc> file


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Perl-Critic-TooMuchCode.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libperl-critic-toomuchcode-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
