### PR TITLE
CI tweaks: more perl versions to test with.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-latest', 'macos-14', 'macos-13']
         perl: [ '5.38', '5.36', '5.34', '5.32', '5.30' ]
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        perl: [ '5.32', '5.30' ]
+        perl: [ '5.38', '5.36', '5.34', '5.32', '5.30' ]
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds the following variants to CI:

- 5.34, 5.36, 5.38
- macOS-14 and macOS-13